### PR TITLE
Added Jib Maven Plugin to build and push Docker images of the applica…

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,22 +13,19 @@ services:
     networks:
       - postgres
     restart: unless-stopped
-  pgadmin:
-    container_name: pgadmin
-    image: dpage/pgadmin4
+
+  spring-boot-example:
+    container_name: kareemabdo-api
+    image: kareemabdose/spring-boot-example
     environment:
-      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-pgadmin4@pgadmin.org}
-      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
-      PGADMIN_CONFIG_SERVER_MODE: 'False'
-    volumes:
-      - pgadmin:/var/lib/pgadmin
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/customer
     ports:
-      - "5050:80"
+      - "8088:8080"
     networks:
       - postgres
-    restart: unless-stopped
     depends_on:
       - db
+    restart: unless-stopped
 
 networks:
   postgres:

--- a/pom.xml
+++ b/pom.xml
@@ -8,26 +8,20 @@
 		<version>3.3.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
-	<groupId>com.kareemabdo</groupId>
+	<groupId>com.kareemabdose</groupId>
 	<artifactId>spring-boot-example</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
+	<organization>
+		<name>kareemabdose</name>
+		<url>https://kareemabdo.com</url>
+	</organization>
+
 	<name>spring-boot-example</name>
 	<description>Demo project for Spring Boot</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
+
 	<properties>
 		<java.version>17</java.version>
+		<docker.username>kareemabdose</docker.username>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -163,6 +157,33 @@
 						</configuration>
 					</execution>
 				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>com.google.cloud.tools</groupId>
+				<artifactId>jib-maven-plugin</artifactId>
+				<version>3.4.3</version>
+				<configuration>
+					<from>
+						<image>eclipse-temurin:17</image>
+						<platforms>
+							<platform>
+								<architecture>arm64</architecture>
+								<os>linux</os>
+							</platform>
+							<platform>
+								<architecture>amd64</architecture>
+								<os>linux</os>
+							</platform>
+						</platforms>
+					</from>
+					<to>
+						<image>docker.io/${organization.name}/${project.artifactId}:${project.version}</image>
+						<tags>
+							<tag>latest</tag>
+						</tags>
+					</to>
+				</configuration>
 			</plugin>
 
 		</plugins>


### PR DESCRIPTION
…tion.

Integrated Jib Maven Plugin for seamless Docker image creation and pushing without needing a Dockerfile. Docker images are built directly from the Maven build process and pushed to Docker Hub under the organization and project name. Enabled easy deployment and containerization of the Spring Boot application using Docker Desktop and Docker Hub.