### PR TITLE
Make /ping API public without authentication

### DIFF
--- a/backend/src/main/java/com/kareemabdo/security/SecurityFilterChainConfig.java
+++ b/backend/src/main/java/com/kareemabdo/security/SecurityFilterChainConfig.java
@@ -42,6 +42,11 @@ public class SecurityFilterChainConfig {
                         "/api/v1/auth/login"
                 )
                 .permitAll()
+                .requestMatchers(
+                        HttpMethod.GET,
+                        "/ping"
+                )
+                .permitAll()
                 .anyRequest()
                 .authenticated()
                 .and()


### PR DESCRIPTION
Updated the /ping endpoint to be publicly accessible. Removed any authentication or authorization checks from this endpoint to allow unauthenticated users to access the health/status check. Ensured this change does not affect other secured routes.